### PR TITLE
fix: use int as getopt retval for portability

### DIFF
--- a/client/chlist.c
+++ b/client/chlist.c
@@ -15,8 +15,8 @@ usage()
 int
 main(int argc, char *argv[])
 {
-	char opt, *server = NULL;
-	int num_servers = 0;
+	char *server = NULL;
+	int opt, num_servers = 0;
 	void (*display)(int) = ring_list_display;
 
 	while ((opt = getopt(argc, argv, "cn:s:V")) != -1) {


### PR DESCRIPTION
`char` should not be used for the return value of `getopt`.
`getopt` returns `-1` when `getopt` reaches the end, but whether `char` is signed depends on environment.
If `char` is unsigned value, it returns `255` instead of `-1`.